### PR TITLE
Fix to recovery date format 

### DIFF
--- a/src/app/components/account/account.module.ts
+++ b/src/app/components/account/account.module.ts
@@ -7,6 +7,7 @@ import { MaterialModule } from '../../material.module';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { AccountRoutingModule } from './account-routing.module';
 import { AppSharedModule } from '../../shared/app-shared.module';
+import { DatePipe } from '@angular/common';
 
 @NgModule({
     imports: [
@@ -22,10 +23,11 @@ import { AppSharedModule } from '../../shared/app-shared.module';
         CreateAccountComponent,
         RecoverAccountComponent,
     ],
+    providers: [DatePipe],
     exports: [
         CreateAccountComponent,
         RecoverAccountComponent
-    ],
+    ]
 })
 export class AccountModule {
 }

--- a/src/app/components/account/recover/recover.component.html
+++ b/src/app/components/account/recover/recover.component.html
@@ -14,7 +14,7 @@
 
             <p>
                 <mat-form-field>
-                    <input matInput [min]="minDate" [max]="maxDate" [(ngModel)]="accountDate" formControlName="accountDate" [matDatepicker]="picker" placeholder="Choose a date">
+                    <input matInput [min]="minDate | date: 'yyyy-MM-dd'" [max]="maxDate | date: 'yyyy-MM-dd'" [(ngModel)]="accountDate" formControlName="accountDate" [matDatepicker]="picker" placeholder="Choose a date">
                     <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
                     <mat-datepicker #picker></mat-datepicker>
                 </mat-form-field>

--- a/src/app/components/account/recover/recover.component.ts
+++ b/src/app/components/account/recover/recover.component.ts
@@ -9,6 +9,7 @@ import { WalletRecovery } from '../../../classes/wallet-recovery';
 import { ApiService } from '../../../services/api.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ApplicationStateService } from '../../../services/application-state.service';
+import { DatePipe } from '@angular/common';
 
 @Component({
     selector: 'app-account-recover',
@@ -49,7 +50,8 @@ export class RecoverAccountComponent {
         public snackBar: MatSnackBar,
         private router: Router,
         private appState: ApplicationStateService,
-        private apiService: ApiService) {
+        private apiService: ApiService,
+        private datePipe: DatePipe) {
 
         this.minDate = this.apiService.genesisDate;
         this.maxDate = new Date(); // Set to current date.


### PR DESCRIPTION
max and min dates were not formatted as per the standard yyyy-MM-dd
This fix properly formats the date as to pick the correct maximum and minimum date.

Important Note:
This recovery date is used as min=genesis date, and max=today.
The genesis date  as defined in /services/chain.service.ts uses the the Date() object which has an important peculiarity which is easy overlooked.
The Date() function actually uses a monthIndex instead of a the month number.
If you define Date(2022,2,28) this is actually 28th MARCH 2022, and not of February which you would think.
January is monthIndex=0
February is monthindex=1
etc.
so valid values is from 0 - 11 from January to December respectively.
This is important as i can see dates like "2018,1,1" in my view is trying to specify first of january 2018, but this is actually first of February...  The genesis dates in chain.service.ts must be reviewed, and updated (if they are not defined as intended).

The issue will become most evident when you are trying to restore an account created on the 1st month of the genesis date of the chain.

Reference: [Mozilla JS Reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date#syntax
)
> monthIndex
> Integer value representing the month, beginning with 0 for January to 11 for December. If a value greater than 11 is passed in, then those months will be added to the date; for example, new Date(1990, 12, 1) will return January 1st, 1991