### PR TITLE
Fix rendering of the release notes

### DIFF
--- a/src/app/components/update/update.component.html
+++ b/src/app/components/update/update.component.html
@@ -7,9 +7,7 @@
             <mat-card-subtitle>Version: {{updateService.info.version}} ({{updateService.info.releaseDate}})</mat-card-subtitle>
         </mat-card-header>
         <mat-card-content>
-            <p>
-                {{updateService.info.releaseNotes}}
-            </p>
+            <p [innerHTML]="updateService.info.releaseNotes" ></p>
             <p *ngIf="updateService.progress && updateService.progress.percent !== 100">
                 <mat-progress-bar mode="determinate" bufferValue="0" mode="buffer" [value]="updateService.progress.percent"></mat-progress-bar>
                 <br>({{updateService.progress.transferred | sizeUnit}}/{{updateService.progress.total | sizeUnit}})


### PR DESCRIPTION
Release notes are in HTML format, when an update is created, the html is presented to the user on the wallet, and not the rendered output.

This fix specifies the data is in html format, hence renders it correctly to the end user.